### PR TITLE
Add custom opts forwarding for tilelive-vector

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,26 @@ function injectAsync(source) {
             switch (opts.type) {
                 case undefined:
                 case 'tile':
-                    source.getTile(opts.z, x, y, (err, data, hdrs) => {
+                    var cb = function(err, data, hdrs) {
                         if (err) {
                             reject(err);
                         } else {
                             resolve({data: data, headers: hdrs});
                         }
-                    });
+                    };
+
+                    // fallback for tilelive-vector
+                    cb.format = opts.format;
+                    cb.scale = opts.scale;
+                    cb.profile = opts.profile;
+                    cb.legacy = opts.legacy;
+                    cb.upgrade = opts.upgrade;
+                    cb.renderer = opts.renderer;
+                    cb.setSrcData = opts.setSrcData;
+                    cb.raw_buffer = opts.raw_buffer;
+                    cb.treatAsVector = opts.treatAsVector;
+
+                    source.getTile(opts.z, x, y, cb );
                     break;
                 case 'grid':
                     source.getGrid(opts.z, x, y, (err, data, hdrs) => {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "tilelive-promise",
-  "version": "2.0.0",
+  "name": "@wikimedia/tilelive-promise",
+  "version": "2.1.0",
   "description": "Adds an extended Promise-based interface to the existing tilelive components, or exposes new components to older tilelive systems.",
   "main": "index.js",
   "scripts": {
     "test": "mocha",
     "preversion": "npm test"
   },
-  "repository": "kartotherian/tilelive-promise",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/wikimedia/tilelive-promise.git"
+  },
   "keywords": [
     "tilelive",
     "promise",
@@ -17,6 +20,7 @@
   "license": "MIT",
   "bugs": "https://github.com/kartotherian/tilelive-promise/issues",
   "homepage": "https://github.com/kartotherian/tilelive-promise#readme",
+  "files": [ "index.js" ],
   "dependencies": {
     "quadtile-index": "^0.0.6"
   },


### PR DESCRIPTION
Upstream tilelive-vector expect these options as part of the callback. In kartotherian they're forwarded to the Async methods.

Including this fallback here avoids a more complicated hack on the tilelive-vector lib.